### PR TITLE
Updated the property value to match the real value, and adjusted the …

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-my.prop=some.value.then.${var}
+my.prop=G0001.${date:now:yyyyMMdd.HHmmss}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-my.prop=G0001.${date:now:yyyyMMdd.HHmmss}
+my.prop=G0001.${a:$}{date:now:yyyyMMdd.HHmmss}

--- a/src/test/java/sample/EscapePropertiesApplicationTests.java
+++ b/src/test/java/sample/EscapePropertiesApplicationTests.java
@@ -16,7 +16,7 @@ public class EscapePropertiesApplicationTests {
 
 	@Test
 	public void configProps() {
-		assertThat(my.getProp()).isEqualTo("some.value.then.${var}");
+		assertThat(my.getProp()).isEqualTo("G0001.${date:now:yyyyMMdd.HHmmss}");
 	}
 
 }


### PR DESCRIPTION
Final update here - the winning value is this:

```
G0001.${a:$}{date:now:yyyyMMdd.HHmmss}
```

The _${a:$}_ evaluates down to _$_, which is then left in front of the _{date:...}_ string.  

Woohoo!!
